### PR TITLE
Adds valkey-7.2.4-rc1.tar.gz

### DIFF
--- a/README
+++ b/README
@@ -18,3 +18,4 @@
 # specified file.
 
 hash valkey-unstable.tar.gz sha256 0000000000000000000000000000000000000000000000000000000000000000 https://github.com/valkey-io/valkey/archive/unstable.tar.gz
+hash valkey-7.2.4-rc1.tar.gz sha256 cd0a74184f2e6addac458f7b4f7549521e490a4ef51db0eb1dccd1a520de4cb6 https://github.com/valkey-io/valkey/archive/refs/tags/7.2.4-rc1.tar.gz


### PR DESCRIPTION
Adds valkey-7.2.4-rc1.tar.gz
<img width="635" alt="Screenshot 2024-04-09 at 11 25 43 AM" src="https://github.com/valkey-io/valkey-hashes/assets/117414976/181cee88-6e7d-4fc6-808c-945e94b20cda">
