### PR TITLE
Add valkey 7.2.6 and 8.0.1

### DIFF
--- a/README
+++ b/README
@@ -24,3 +24,5 @@ hash valkey-7.2.6.tar.gz sha256 5272f244deecd5655d805aabc71c84a7c7699bc4fa009dd7
 hash valkey-8.0.0-rc1.tar.gz sha256 0455cbc76c8d4cbddfe9a668cd5d41fe7c35ce4ab4e2bbe89128e9fed3cb72b0 https://github.com/valkey-io/valkey/archive/refs/tags/8.0.0-rc1.tar.gz
 hash valkey-8.0.0-rc2.tar.gz sha256 7592865c60578cc6d9f5cd5f0a6f77d946ac21a71bf9863bcf18b5e2835ae065 https://github.com/valkey-io/valkey/archive/refs/tags/8.0.0-rc2.tar.gz
 hash valkey-8.0.0.tar.gz sha256 f87fef2ba81ae4bce891b874fba58cfde2d19370a3bcac20f0e17498b33c33c0 https://github.com/valkey-io/valkey/archive/refs/tags/8.0.0.tar.gz
+hash valkey-8.0.1.tar.gz sha256 1e1d6dfbed2f932a87afbc7402be050a73974a9b19a9116897e537a6638e5e1d https://github.com/valkey-io/valkey/archive/refs/tags/8.0.1.tar.gz
+hash valkey-7.2.7.tar.gz sha256 8aae9c7d2c007a6b7c7221f65a420525a7a0106be66dfaa161ad6f3438509334 https://github.com/valkey-io/valkey/archive/refs/tags/7.2.7.tar.gz


### PR DESCRIPTION
```
matolson@88665a372227 valkey % VERSION=8.0.1;    
curl -LO https://github.com/valkey-io/valkey/archive/refs/tags/$VERSION.tar.gz && shasum -a 256 "$(basename https://github.com/valkey-io/valkey/archive/refs/tags/$VERSION.tar.gz)"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 3540k    0 3540k    0     0  4311k      0 --:--:-- --:--:-- --:--:-- 7563k
1e1d6dfbed2f932a87afbc7402be050a73974a9b19a9116897e537a6638e5e1d  8.0.1.tar.gz
matolson@88665a372227 valkey % VERSION=7.2.7;
curl -LO https://github.com/valkey-io/valkey/archive/refs/tags/$VERSION.tar.gz && shasum -a 256 "$(basename https://github.com/valkey-io/valkey/archive/refs/tags/$VERSION.tar.gz)"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 3350k  100 3350k    0     0  9410k      0 --:--:-- --:--:-- --:--:-- 9410k
8aae9c7d2c007a6b7c7221f65a420525a7a0106be66dfaa161ad6f3438509334  7.2.7.tar.gz
```