### PR TITLE
Revert "Update hash for version 8.1.0-rc2"

### DIFF
--- a/README
+++ b/README
@@ -17,7 +17,7 @@
 # Digest is the output of the hash function, and URL the download URL for the
 # specified file.
 
-hash valkey-8.1.0-rc2.tar.gz sha256 928769d2b8172052912a6bb65a46a10f9d420a3b54c7a9ad46bc451cc901fb27 https://github.com/valkey-io/valkey/archive/refs/tags/8.1.0-rc2.tar.gz
+hash valkey-unstable.tar.gz sha256 0000000000000000000000000000000000000000000000000000000000000000 https://github.com/valkey-io/valkey/archive/unstable.tar.gz
 hash valkey-7.2.4-rc1.tar.gz sha256 cd0a74184f2e6addac458f7b4f7549521e490a4ef51db0eb1dccd1a520de4cb6 https://github.com/valkey-io/valkey/archive/refs/tags/7.2.4-rc1.tar.gz
 hash valkey-7.2.5.tar.gz sha256 c7c7a758edabe7693b3692db58fe5328130036b06224df64ab1f0c12fe265a76 https://github.com/valkey-io/valkey/archive/refs/tags/7.2.5.tar.gz
 hash valkey-7.2.6.tar.gz sha256 5272f244deecd5655d805aabc71c84a7c7699bc4fa009dd7fc550806a042d512 https://github.com/valkey-io/valkey/archive/refs/tags/7.2.6.tar.gz


### PR DESCRIPTION
This reverts commit 6f42f5eb30311ff9d751ebedcf960931831ffa52.