### PR TITLE
Removed duplicate hash for version 8.1.3

### DIFF
--- a/README
+++ b/README
@@ -34,7 +34,6 @@ hash valkey-7.2.9.tar.gz sha256 d05cb3307752314083cf73628f2b8413a4445b8afb7ac27d
 hash valkey-8.0.3.tar.gz sha256 9141b6a91572e714fae8bc01e5031828ac6a8eb8e012e6836673d18dbfe4a47b https://github.com/valkey-io/valkey/archive/refs/tags/8.0.3.tar.gz
 hash valkey-8.1.1.tar.gz sha256 3355fbd5458d853ab201d2c046ffca9f078000587ccbe9a6c585110f146ad2c5 https://github.com/valkey-io/valkey/archive/refs/tags/8.1.1.tar.gz
 hash valkey-8.1.2.tar.gz sha256 747b272191c15c7387f4ad3b3e7eda16deb1cffc6425e0571547f54e4d2e3646 https://github.com/valkey-io/valkey/archive/refs/tags/8.1.2.tar.gz
-hash valkey-8.1.3.tar.gz sha256 6b167eb7072f5785c0c0af807960889a3d346fc3d0ecb571064b019ee365ee00 https://github.com/valkey-io/valkey/archive/refs/tags/8.1.3.tar.gz
 hash valkey-8.0.4.tar.gz sha256 f6022a27af9d3c43480c04fd750bc50b1853e3d080bd40d04e3f1e43f0fdc3eb https://github.com/valkey-io/valkey/archive/refs/tags/8.0.4.tar.gz
 hash valkey-8.1.3.tar.gz sha256 8f862b3b0a72fd40587793964539589f6f83d01361ca1598b370cfaa301e0ec0 https://github.com/valkey-io/valkey/archive/refs/tags/8.1.3.tar.gz
 hash valkey-8.0.4.tar.gz sha256 55c12a25f67ef19b615c76b6cb0c92d12753d76eb8d38b31d30e299c3490cdf2 https://github.com/valkey-io/valkey/archive/refs/tags/8.0.4.tar.gz


### PR DESCRIPTION
Helps resolve this issue: https://github.com/valkey-io/valkey/issues/2601